### PR TITLE
feat: fetch total market size dynamically

### DIFF
--- a/src/app/state/ILM/hooks/useFetchIlmPageHeader.tsx
+++ b/src/app/state/ILM/hooks/useFetchIlmPageHeader.tsx
@@ -1,7 +1,4 @@
-import {
-  loopStrategyAbi,
-  useReadLoopStrategyCollateral,
-} from "../../../generated/generated";
+import { loopStrategyAbi } from "../../../generated/generated";
 import {
   formatToDisplayable,
   formatUnitsToNumber,


### PR DESCRIPTION
Hook for fetching ILM header data is updated to fetch collateral from all strategies and sum them up in order to provider total market size across all strategies. After this is merged first page of our app is completely agnostic to how many strategies are there. It will work with 1 and it should work with 100 with minimal changes in config structure.

Resolves #27 