### PR TITLE
ci: use relative paths for 3rdparty ipfs gateways

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
 
   return {
+    base: "",
     plugins: [
       nodePolyfills(),
       react(),


### PR DESCRIPTION
This is to allow assets to load even if the app is not hosted at the root `/`. Some users may access the site through it's IPFS hash on a gateway like `{ipfs-gateway}.com/{ipfs-hash}/index.html`