### PR TITLE
fix: implement strategy price denomination in debt asset

### DIFF
--- a/src/app/statev3/hooks/strategy-analytics/StrategyAnalytics.all.ts
+++ b/src/app/statev3/hooks/strategy-analytics/StrategyAnalytics.all.ts
@@ -36,14 +36,19 @@ export const fetchStrategyAnalytics = async (strategy: Address, filter: FilterOp
       const totalPoints = data?.result?.rows?.length || 0;
       const targetPoints = 70;
 
-      let skip = 1;
-      if (totalPoints > targetPoints) {
-        skip = Math.ceil(totalPoints / targetPoints);
-      }
+      const skip = totalPoints > targetPoints ? Math.ceil(totalPoints / targetPoints) : 1;
 
-      const filteredData = data?.result?.rows?.filter((_: any, index: number) => index % skip === 0);
+      const modifiedData = data?.result?.rows
+        ?.filter((_: any, index: number) => index % skip === 0)
+        .map((row: any) => {
+          return {
+            share_value_usd: row.share_value_usd,
+            share_value_in_debt_asset: row.share_value_usd / row.debt_token_price,
+            time: row.time,
+          };
+        });
 
-      return filteredData;
+      return modifiedData;
     },
     ...analyticsDataQueryConfig,
   });

--- a/src/app/v3/pages/ilm-details/components/graph/GraphComponent.tsx
+++ b/src/app/v3/pages/ilm-details/components/graph/GraphComponent.tsx
@@ -14,13 +14,17 @@ import { Address } from "viem";
 import "./GraphComoonent.css";
 
 export interface DuneData {
+  share_value_in_debt_asset: number;
   share_value_usd: number;
-  underlying_asset_price: number;
-  strategy: string;
   time: string;
 }
 
 const FilterOptions: FilterOption[] = ["1w", "1m", "3m", "1y"];
+
+// TODO: Fix this function and find scalable solution when we decide on long term graph solution
+const numberOfDecimals = (value: number): number => {
+  return value < 1 ? 5 : 2;
+};
 
 const formatDate = (value: string, includeTime = false) => {
   const date = new Date(value);
@@ -47,8 +51,8 @@ export const GraphComponent = () => {
   const [filterOption, setFilterOption] = useState<FilterOption>("1w");
   const [chartOptions, setChartOptions] = useState<ApexOptions>({});
   const [chartSeries, setChartSeries] = useState<{ name: string; data: number[] }[]>([]);
-  const [showLpTokenPrice, setShowLpTokenPrice] = useState(true);
-  const [showLpTokenAmount, setShowLpTokenAmount] = useState(false);
+  const [showPriceInDebtAsset, setShowPriceInDebtAsset] = useState(true);
+  const [showPriceInUsd, setShowPriceInUsd] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -72,17 +76,17 @@ export const GraphComponent = () => {
       const categories = data?.map((item) => item.time);
       const series = [];
 
-      if (showLpTokenPrice && data) {
+      if (showPriceInDebtAsset && data) {
         series.push({
-          name: "Share Value USD",
-          data: data.map((item) => item.share_value_usd),
+          name: "Share Value In Debt Asset",
+          data: data.map((item) => item.share_value_in_debt_asset),
         });
       }
 
-      if (showLpTokenAmount && data) {
+      if (showPriceInUsd && data) {
         series.push({
-          name: "Underlying Asset Price USD",
-          data: data.map((item) => item.underlying_asset_price),
+          name: "Share Value USD",
+          data: data.map((item) => item.share_value_usd),
         });
       }
 
@@ -102,7 +106,7 @@ export const GraphComponent = () => {
             easing: "easeout",
           },
         },
-        colors: showLpTokenPrice ? ["#4F68F7", "#00E396"] : ["#00E396"],
+        colors: showPriceInDebtAsset ? ["#4F68F7", "#00E396"] : ["#00E396"],
         dataLabels: {
           enabled: false,
         },
@@ -119,7 +123,7 @@ export const GraphComponent = () => {
         },
         yaxis: {
           labels: {
-            formatter: (value) => `$ ${value.toFixed(2)}`,
+            formatter: (value) => `${value.toFixed(numberOfDecimals(value))}`,
           },
         },
         tooltip: {
@@ -157,17 +161,17 @@ export const GraphComponent = () => {
       setChartSeries(series);
     };
     processData();
-  }, [filterOption, showLpTokenPrice, showLpTokenAmount, strategy]);
+  }, [filterOption, showPriceInDebtAsset, showPriceInUsd, strategy]);
 
   return (
     <div className="flex flex-col w-full rounded-card bg-neutral-0 py-6 px-8 gap-8">
       <Heading />
       <div className="flex gap-2">
-        <GraphButton isActive={showLpTokenPrice} onClick={() => setShowLpTokenPrice((prev) => !prev)}>
-          Share Value (USD)
+        <GraphButton isActive={showPriceInDebtAsset} onClick={() => setShowPriceInDebtAsset((prev) => !prev)}>
+          Share Value (Debt Asset)
         </GraphButton>
-        <GraphButton isActive={showLpTokenAmount} onClick={() => setShowLpTokenAmount((prev) => !prev)}>
-          Underlying Asset (USD)
+        <GraphButton isActive={showPriceInUsd} onClick={() => setShowPriceInUsd((prev) => !prev)}>
+          Share Value (USD)
         </GraphButton>
       </div>
       <div>


### PR DESCRIPTION
Changed graph to present strategy share value in debt asset and in USD. This means that I removed graph for underlying asset. Now API returns debt_token_price which means that in order to display strategy share value in debt asset we need to divide share value in USD with debt asset price (share_value_usd / debt_token_price). Now function that returns data for graph component returns share_value_usd and share_value_in_debt_asset and also time. 

I changed naming a little bit but no functionality should be effected. Also I changed number of decimals and removed dollar sign on Y oasis because we don't display dollar value always but sometimes value denominated in debt asset. Decimals are changed because of ETH short strategy where debt asset is ETH and share value in debt asset is often 0.000xxx. If we always round on 2 decimals 0.00 is always shown and because of that I implemented quick fix but I left TODO comment so we can later come back to this and make proper formatting function.