### PR TITLE
ci: set environment for deploy action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: FrontendDeploymentAction
+name: Production IPFS Deployment
 
 on:
   workflow_dispatch:
@@ -6,6 +6,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    environment: production-ipfs
 
     strategy:
       matrix:


### PR DESCRIPTION
Set the job to run only using the production-ipfs environment created. Also renamed to CD from CI, since this is a CD job not CI job.

I tested on a personal fork repo that the environment is respected correctly. Before adding ENV vars the job logs this:
![Screenshot 2024-11-29 at 12 28 34 PM](https://github.com/user-attachments/assets/10db281f-339d-4637-8bcf-3a007e4d8da3)

After adding sentry env, this log is gone: https://github.com/fredwes/seamless-interface/actions/runs/12090293069/job/33717024410