### PR TITLE
added node_env to build command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,7 +45,7 @@ jobs:
           echo VITE_DUNE_CACHE_API=${{ secrets.VITE_DUNE_CACHE_API }} >> .env.production
 
       - run: npm ci
-      - run: NODE_ENV=production npm run build --if-present
+      - run: npm run build --if-present
 
       - name: Rename dist folder
         run: |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "compile": "tsc -p tsconfig.build.json",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 10",
     "lint:fix": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0 --fix --no-cache",
-    "prebuild": "npm run switch-tailwind-config && npm run lint && npm run compile",
+    "prebuild": "NODE_ENV=production npm run switch-tailwind-config && npm run lint && npm run compile",
     "build": "vite build",
     "build:prod": "npx cypress run && npm run build",
     "anvil": "node run-anvil.mjs",


### PR DESCRIPTION
it was a problem with NODE_ENV not being set. this is actually not a rare situation, because NODE_ENV could be automatically set by IDE or other things on local machine, and not set on some server..

confirming that it is now using v3 styling on my fork test:
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/f5b2db49-85e1-478a-88c9-3d8b7abd9c88">
