### PR TITLE
Leverage tokens details without form

### DIFF
--- a/src/app/data/leverage-tokens/queries/all-leverage-tokens/FetchAllLeverageTokens.ts
+++ b/src/app/data/leverage-tokens/queries/all-leverage-tokens/FetchAllLeverageTokens.ts
@@ -15,6 +15,8 @@ export interface ViewRewardToken {
 
 export interface LeverageToken {
   address: Address;
+  underlyingAssetAddress: Address;
+  underlyingAsset: Token;
   tvl: {
     tokenAmount: ViewBigInt;
     dollarAmount: ViewBigInt;
@@ -31,14 +33,28 @@ export interface LeverageToken {
   };
   tokenData: Token;
   additionalData: {
-    description: string;
+    description?: string;
   };
   type?: TagType;
+  /** Range for rebalancing leverage */
+  targetMultiples: {
+    minForRebalance?: ViewBigInt;
+    maxForRebalance?: ViewBigInt;
+  };
+  /** Current leverage multiple */
+  currentMultiple: ViewBigInt;
 }
 
 export const mockLeverageTokens: LeverageToken[] = [
   {
     address: "0x1111111111111111111111111111111111111111" as Address,
+    underlyingAssetAddress: "0x1111111111111111111111111111111111111111" as Address,
+    underlyingAsset: {
+      symbol: "ETH",
+      decimals: 18,
+      name: "Ethereum",
+      logo: mockLogo,
+    },
     type: "Short",
     tvl: {
       tokenAmount: formatFetchBigIntToViewBigInt({
@@ -52,6 +68,11 @@ export const mockLeverageTokens: LeverageToken[] = [
         symbol: "$",
       }),
     },
+    targetMultiples: {
+      minForRebalance: formatFetchBigIntToViewBigInt({ bigIntValue: 1n * 10n ** 18n, decimals: 18, symbol: "x" }),
+      maxForRebalance: formatFetchBigIntToViewBigInt({ bigIntValue: 3n * 10n ** 18n, decimals: 18, symbol: "x" }),
+    },
+    currentMultiple: formatFetchBigIntToViewBigInt({ bigIntValue: 2n * 10n ** 18n, decimals: 18, symbol: "x" }),
     apy: {
       rewardTokens: [],
       yieldAPY: formatFetchNumberToViewNumber({
@@ -91,6 +112,13 @@ export const mockLeverageTokens: LeverageToken[] = [
   },
   {
     address: "0x2222222222222222222222222222222222222222" as Address,
+    underlyingAssetAddress: "0x1111111111111111111111111111111111111111" as Address,
+    underlyingAsset: {
+      symbol: "ETH",
+      decimals: 18,
+      name: "Ethereum",
+      logo: mockLogo,
+    },
     type: "Long",
     tvl: {
       tokenAmount: formatFetchBigIntToViewBigInt({
@@ -104,6 +132,11 @@ export const mockLeverageTokens: LeverageToken[] = [
         symbol: "$",
       }),
     },
+    targetMultiples: {
+      minForRebalance: formatFetchBigIntToViewBigInt({ bigIntValue: 1n * 10n ** 18n, decimals: 18, symbol: "x" }),
+      maxForRebalance: formatFetchBigIntToViewBigInt({ bigIntValue: 3n * 10n ** 18n, decimals: 18, symbol: "x" }),
+    },
+    currentMultiple: formatFetchBigIntToViewBigInt({ bigIntValue: 2n * 10n ** 18n, decimals: 18, symbol: "x" }),
     apy: {
       rewardTokens: [],
       yieldAPY: formatFetchNumberToViewNumber({

--- a/src/app/data/leverage-tokens/queries/leverage-token-by-address/FetchLeverageTokenByAddress.ts
+++ b/src/app/data/leverage-tokens/queries/leverage-token-by-address/FetchLeverageTokenByAddress.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { Address, isAddressEqual } from "viem";
+import { LeverageToken, mockLeverageTokens } from "../all-leverage-tokens/FetchAllLeverageTokens";
+
+/**
+ * Mock fetchLeverageTokenByAddress: returns a single token by address (or undefined if not found)
+ */
+export async function fetchLeverageTokenByAddress(address: Address): Promise<LeverageToken | undefined> {
+  // simulate network latency
+  // eslint-disable-next-line no-promise-executor-return
+  await new Promise((r) => setTimeout(r, 1500));
+  return mockLeverageTokens.find((token) => isAddressEqual(token.address, address));
+}
+
+export function useFetchLeverageTokenByAddress(address?: Address) {
+  return useQuery<LeverageToken | undefined>({
+    queryKey: ["hookFetchLeverageTokenByAddress", address],
+    queryFn: () => fetchLeverageTokenByAddress(address!),
+    enabled: Boolean(address),
+  });
+}

--- a/src/app/router/index.ts
+++ b/src/app/router/index.ts
@@ -57,6 +57,7 @@ export const RouterConfig = {
     developers: `${developersUrl}`,
     ilmDetails: `${baseUrl}/ilm-detailsv2/:id`,
     ilmDetailsv3: `${baseUrl}/ilm-details/:address`,
+    leverageToken: `${baseUrl}/leverage-token-details/:address`,
     morphoVaultDetailsv3: `${baseUrl}/vault-details/:address`,
     morphoVaultsTab: `${baseUrl}/?tab=Vaults`,
   },
@@ -64,6 +65,7 @@ export const RouterConfig = {
   Builder: {
     ilmDetailsv2: (id: number) => `${baseUrl}/ilm-detailsv2/${id}`,
     ilmDetails: (address: Address) => `${baseUrl}/ilm-details/${address}`,
+    leverageTokenDetails: (address: Address) => `${baseUrl}/leverage-token-details/${address}`,
     morphoVaultDetails: (address: Address) => `${baseUrl}/vault-details/${address}`,
     assetDetails: (address: Address) =>
       `${lendingAndBorrowingUrl}/reserve-overview/?underlyingAsset=${address.toLowerCase()}&marketName=proto_base_v3`,

--- a/src/app/v3/App.tsx
+++ b/src/app/v3/App.tsx
@@ -20,6 +20,7 @@ import { getApolloClient } from "../config/apollo-client";
 import { ApolloProvider } from "@apollo/client";
 import { MorphoVaultDetails } from "./pages/morpho-vault-details/MorphoVaultDetails";
 import { GovernancePage } from "./pages/governance/GovernancePage";
+import { LeverageTokenDetailsPage } from "./pages/leverage-token-details/LeverageTokenDetailsPage";
 
 const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
 
@@ -41,6 +42,9 @@ export function App() {
                   <SentryRoutes>
                     <Route path={RouterConfig.Routes.landingPage} element={<LandingPage />} />
                     <Route path={RouterConfig.Routes.ilmDetailsv3} element={<ILMDetails />} />
+                    {import.meta.env.VITE_LEVERAGE_TOKENS_FEATURE === "true" && (
+                      <Route path={RouterConfig.Routes.leverageToken} element={<LeverageTokenDetailsPage />} />
+                    )}
                     <Route path={RouterConfig.Routes.morphoVaultDetailsv3} element={<MorphoVaultDetails />} />
                     <Route path={RouterConfig.Routes.governance} element={<GovernancePage />} />
                     <Route path="*" element={<PageNotFound />} />

--- a/src/app/v3/components/other/SignIndicatingElement.tsx
+++ b/src/app/v3/components/other/SignIndicatingElement.tsx
@@ -1,8 +1,8 @@
-import { Displayable, FlexRow, Icon, ViewBigInt } from "@shared";
+import { Displayable, FlexRow, Icon, ViewBigInt, ViewNumber } from "@shared";
 import { getBackGroundColorBasedOnSign, getColorBasedOnSign, getSvgBasedOnSign } from "../../utils/uiUtils";
 
 export const SignIndicatingElement: React.FC<{
-  dislayable: Displayable<ViewBigInt>;
+  dislayable: Displayable<ViewBigInt | ViewNumber | undefined>;
   children: React.ReactNode;
   noBackground?: boolean;
 }> = ({ dislayable, children, noBackground }) => {
@@ -15,10 +15,10 @@ export const SignIndicatingElement: React.FC<{
   return (
     <FlexRow
       className={`items-center gap-1 p-2 rounded-tag
-       ${noBackground ? "" : getBackGroundColorBasedOnSign(data.value)}
-      ${getColorBasedOnSign(data.value)}`}
+       ${noBackground ? "" : getBackGroundColorBasedOnSign(data?.value)}
+      ${getColorBasedOnSign(data?.value)}`}
     >
-      <Icon src={getSvgBasedOnSign(data.value)} alt="polygon" width={16} height={16} hidden={!data.bigIntValue} />
+      <Icon src={getSvgBasedOnSign(data?.value)} alt="polygon" width={16} height={16} hidden={!Number(data?.value)} />
       {children}
     </FlexRow>
   );

--- a/src/app/v3/pages/landing-page/tabs/ilms/table/IlmTableContainer.tsx
+++ b/src/app/v3/pages/landing-page/tabs/ilms/table/IlmTableContainer.tsx
@@ -52,7 +52,7 @@ export const LeverageTokensTableContainer: React.FC<{
       >
         {leverageTokens?.map((lvrgToken, index) => (
           <div key={index}>
-            <Link data-cy={`table-row-${lvrgToken}`} to={RouterConfig.Builder.ilmDetails(lvrgToken.address)}>
+            <Link data-cy={`table-row-${lvrgToken}`} to={RouterConfig.Builder.leverageTokenDetails(lvrgToken.address)}>
               <LeverageTokenDesktopTableRow
                 leverageToken={{
                   data: {

--- a/src/app/v3/pages/landing-page/tabs/ilms/table/loading-state/mock.ts
+++ b/src/app/v3/pages/landing-page/tabs/ilms/table/loading-state/mock.ts
@@ -28,5 +28,9 @@ export const propsMock: Displayable<LeverageToken> = {
       yieldAPY: emptyViewBigInt,
       rewardTokens: [],
     },
+    currentMultiple: {} as any,
+    targetMultiples: {} as any,
+    underlyingAsset: {} as any,
+    underlyingAssetAddress: "" as any,
   },
 };

--- a/src/app/v3/pages/leverage-token-details/LeverageTokenDetailsPage.tsx
+++ b/src/app/v3/pages/leverage-token-details/LeverageTokenDetailsPage.tsx
@@ -10,7 +10,7 @@ import { LeverageTokenStats } from "./components/stats/LeverageTokenStats";
 import { LeverageTokenHeading } from "./components/heading/LeverageTokenHeading";
 import { LeverageTokenDetails } from "./components/details/LeverageTokenDetails";
 
-export const LeverageTokensDetails = () => {
+export const LeverageTokenDetailsPage = () => {
   const navigate = useNavigate();
   const { address } = useParams();
   const { isConnected } = useAccount();

--- a/src/app/v3/pages/leverage-token-details/LeverageTokenDetailsPage.tsx
+++ b/src/app/v3/pages/leverage-token-details/LeverageTokenDetailsPage.tsx
@@ -1,0 +1,56 @@
+import { FlexCol, FlexRow, PageContainer } from "@shared";
+import { useNavigate, useParams } from "react-router-dom";
+import { Address } from "viem";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { RouterConfig } from "@router";
+import { useAccount } from "wagmi";
+import { CurrentHoldings } from "../../components/current-holdings/CurrentHoldings";
+import { useFetchLeverageTokenByAddress } from "../../../data/leverage-tokens/queries/leverage-token-by-address/FetchLeverageTokenByAddress";
+import { LeverageTokenStats } from "./components/stats/LeverageTokenStats";
+import { LeverageTokenHeading } from "./components/heading/LeverageTokenHeading";
+import { LeverageTokenDetails } from "./components/details/LeverageTokenDetails";
+
+export const LeverageTokensDetails = () => {
+  const navigate = useNavigate();
+  const { address } = useParams();
+  const { isConnected } = useAccount();
+
+  const { data: lvrgToken, ...rest } = useFetchLeverageTokenByAddress(address as Address);
+
+  return (
+    <PageContainer className="flex justify-center py-6 pb-12 px-4 md:px-0">
+      <FlexCol className="gap-1 w-full md:max-w-page-content">
+        <FlexRow className="py-6 items-center gap-4">
+          <button onClick={() => navigate(RouterConfig.Routes.dashboardTab)}>
+            <ArrowLeftIcon width={40} height={40} />
+          </button>
+        </FlexRow>
+
+        <div className="mb-8">
+          <LeverageTokenHeading
+            leverageToken={{
+              data: lvrgToken,
+              ...rest,
+            }}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-[2fr,1fr] gap-8 w-full items-start">
+          <div className="md:sticky top-6 order-1 md:order-2 md:min-w-[460px]">{/* todo: form comes here */}</div>
+
+          <div className="flex flex-col gap-10 order-2 md:order-1">
+            {isConnected && <CurrentHoldings address={address as Address} />}
+            <FlexCol className="px-8 py-6 w-full rounded-xl bg-neutral-0 gap-4">{/* todo graph component */}</FlexCol>
+            <LeverageTokenStats
+              leverageToken={{
+                data: lvrgToken,
+                ...rest,
+              }}
+            />
+            <LeverageTokenDetails />
+          </div>
+        </div>
+      </FlexCol>
+    </PageContainer>
+  );
+};

--- a/src/app/v3/pages/leverage-token-details/components/details/LeverageTokenDetails.tsx
+++ b/src/app/v3/pages/leverage-token-details/components/details/LeverageTokenDetails.tsx
@@ -1,0 +1,3 @@
+export const LeverageTokenDetails = () => {
+  return <div>todo: details</div>;
+};

--- a/src/app/v3/pages/leverage-token-details/components/heading/LeverageTokenHeading.tsx
+++ b/src/app/v3/pages/leverage-token-details/components/heading/LeverageTokenHeading.tsx
@@ -1,0 +1,60 @@
+import { Displayable, DisplayNumber, DisplayText, FlexCol, FlexRow } from "@shared";
+
+import { LeverageToken } from "@app/data/leverage-tokens/queries/all-leverage-tokens/FetchAllLeverageTokens";
+import { SignIndicatingElement } from "../../../../components/other/SignIndicatingElement";
+import { IncentivesButton } from "../../../../components/tooltip/AprTooltip";
+import { IncentivesDetailCard } from "../../../../components/tooltip/IncentivesDetailCard";
+
+export const LeverageTokenHeading: React.FC<{
+  leverageToken: Displayable<LeverageToken | undefined>;
+}> = ({ leverageToken }) => {
+  const {
+    data: {
+      tokenData: { name = undefined, symbol = undefined } = {},
+      apy: { estimatedAPY = undefined, rewardTokens = [] } = {},
+      additionalData: { description = undefined } = {},
+    } = {},
+    ...rest
+  } = leverageToken;
+
+  return (
+    <FlexCol>
+      <div className="flex md:flex-row flex-col-reverse md:items-center gap-4">
+        <DisplayText viewValue={name} {...rest} typography="bold7" />
+
+        <FlexRow className="md:items-center gap-4">
+          <div className="flex w-auto">
+            <SignIndicatingElement
+              dislayable={{
+                ...rest,
+                data: estimatedAPY,
+              }}
+            >
+              <DisplayNumber typography="bold3" {...estimatedAPY} {...rest} />
+            </SignIndicatingElement>
+          </div>
+
+          <div className="h-auto mt-[2px]">
+            <IncentivesButton
+              totalApr={{
+                ...estimatedAPY,
+              }}
+              rewardTokens={rewardTokens}
+              {...rest}
+            >
+              <IncentivesDetailCard
+                assetSymbol={symbol}
+                totalApr={{
+                  ...estimatedAPY,
+                }}
+                rewardTokens={rewardTokens}
+                {...rest}
+              />
+            </IncentivesButton>
+          </div>
+        </FlexRow>
+      </div>
+      {description && <DisplayText {...rest} typography="regular5" text={description} />}
+    </FlexCol>
+  );
+};

--- a/src/app/v3/pages/leverage-token-details/components/stats/LeverageTokenStats.tsx
+++ b/src/app/v3/pages/leverage-token-details/components/stats/LeverageTokenStats.tsx
@@ -1,0 +1,93 @@
+import { Displayable, DisplayMoney, DisplayText, FlexCol, FlexRow, Typography, ViewBigInt } from "@shared";
+import border from "@assets/common/border.svg";
+import { LeverageToken } from "@app/data/leverage-tokens/queries/all-leverage-tokens/FetchAllLeverageTokens";
+
+function getMinMaxLeverageText(min: ViewBigInt | undefined, max: ViewBigInt | undefined): string | undefined {
+  return `${min?.viewValue}${min?.symbol} - ${max?.viewValue}${max?.symbol}`;
+}
+
+const skeletonLoaderSettings = {
+  width: "120px",
+  height: "30px",
+};
+
+export interface LeverageTokenStatsProps {
+  leverageToken: Displayable<LeverageToken | undefined>;
+}
+
+export const LeverageTokenStats: React.FC<LeverageTokenStatsProps> = ({ leverageToken }) => {
+  const {
+    data: {
+      tvl: { dollarAmount = {} } = {},
+      availableSupplyCap: { dollarAmount: capDollarAmount = undefined } = {},
+      targetMultiples: { minForRebalance = undefined, maxForRebalance = undefined } = {},
+      currentMultiple,
+    } = {},
+    ...rest
+  } = leverageToken;
+
+  return (
+    <div className="flex md:flex-row flex-col w-full rounded-card bg-neutral-0 py-8 pl-6 md:min-h-36 gap-5">
+      <FlexRow className="md:w-1/4 justify-between">
+        <FlexCol className="justify-between ">
+          <Typography type="medium3" className="text-primary-600">
+            TVL
+          </Typography>
+          <DisplayMoney
+            {...dollarAmount}
+            {...rest}
+            typography="bold5"
+            className="text-primary-1000"
+            loaderSkeletonSettings={skeletonLoaderSettings}
+          />
+        </FlexCol>
+        <img src={border} alt="border" className="hidden md:block" />
+      </FlexRow>
+      <FlexRow className="md:w-1/4 justify-between">
+        <FlexCol className="max-w-max justify-between">
+          <Typography type="medium3" className="text-primary-600">
+            Supply cap
+          </Typography>
+          <DisplayMoney
+            {...capDollarAmount}
+            {...rest}
+            typography="bold5"
+            className="text-primary-1000"
+            loaderSkeletonSettings={skeletonLoaderSettings}
+          />
+        </FlexCol>
+        <img src={border} alt="border" className="hidden md:block" />
+      </FlexRow>
+      <FlexRow className="md:w-1/4 justify-between">
+        <FlexCol className="justify-between">
+          <Typography type="medium3" className="text-primary-600 md:max-w-20">
+            Min - Max Leverage
+          </Typography>
+          <DisplayText
+            {...rest}
+            typography="bold5"
+            className="text-primary-1000"
+            text={getMinMaxLeverageText(maxForRebalance, minForRebalance)}
+            loaderSkeletonSettings={skeletonLoaderSettings}
+          />
+        </FlexCol>
+        <img src={border} alt="border" className="hidden md:block" />
+      </FlexRow>
+      <FlexRow className="md:w-1/4">
+        <FlexCol className="justify-between">
+          <Typography type="medium3" className="text-primary-600  md:max-w-20">
+            Current leverage
+          </Typography>
+          <DisplayText
+            {...rest}
+            {...currentMultiple}
+            typography="bold5"
+            className="text-primary-1000"
+            symbolPosition="after"
+            loaderSkeletonSettings={skeletonLoaderSettings}
+          />
+        </FlexCol>
+      </FlexRow>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR covers the details page skeleton for leveraged tokens. It fetches leverage token from mock and displays everything except details sections(collapsable text) and form.