### PR TITLE
fix: try/catch univ2 quote

### DIFF
--- a/src/app/data/leverage-tokens/hooks/useFetchUniswapRoute.ts
+++ b/src/app/data/leverage-tokens/hooks/useFetchUniswapRoute.ts
@@ -46,6 +46,7 @@ export const getQuoteAndParamsUniswapV2 = async (args: FetchBestSwapInput): Prom
     if (error instanceof ContractFunctionExecutionError) {
       if (error.message.includes("ds-math-sub-underflow")) {
         // Math subtraction underflow occurred when fetching UniswapV2 quote - due to insufficient liquidity
+        // eslint-disable-next-line no-console
         console.warn("UniswapV2 quote failed: Insufficient liquidity for the swap pair");
         return undefined;
       }


### PR DESCRIPTION
When fetching a univ2 quote, if there is insufficient liquidity for the pair the contract view call reverts here https://github.com/sushiswap/v2-core/blob/master/contracts/libraries/UniswapV2Library.sol#L59. Without this fix, the error is logged to console.

Confirmed this fix works by testing with larger amounts requiring a swap greater than the available liquidity on univ2 on a vnet